### PR TITLE
fix: ASSEMBLY - social links duplicated and twitter link

### DIFF
--- a/post.hbs
+++ b/post.hbs
@@ -72,8 +72,8 @@ into the {body} of the default.hbs template --}}
                   {{#if @custom.discord_page}}
                     <a href={{ @custom.discord_page }}>Discord</a> |
                   {{/if}}
-                  {{#if @custom.twitter}}
-                  <a href={{ @custom.twitter }}>Twitter</a> |
+                  {{#if @custom.twitter_page}}
+                  <a href={{ @custom.twitter_page }}>Twitter</a> |
                   {{/if}}
                   {{#if @custom.linkedin_page}}
                   <a href={{ @custom.linkedin_page }}>LinkedIn</a> |

--- a/post.hbs
+++ b/post.hbs
@@ -70,25 +70,25 @@ into the {body} of the default.hbs template --}}
                 <div>
                   <div>Follow us on our official channels for the latest updates:</div>
                   {{#if @custom.discord_page}}
-                    <a href={{ @custom.discord_page }}>Discord</a> |
+                    <a href={{ @custom.discord_page }} target='_blank' rel='noopener'>Discord</a> |
                   {{/if}}
                   {{#if @custom.twitter_page}}
-                  <a href={{ @custom.twitter_page }}>Twitter</a> |
+                  <a href={{ @custom.twitter_page }} target='_blank' rel='noopener'>Twitter</a> |
                   {{/if}}
                   {{#if @custom.linkedin_page}}
-                  <a href={{ @custom.linkedin_page }}>LinkedIn</a> |
+                  <a href={{ @custom.linkedin_page }} target='_blank' rel='noopener'>LinkedIn</a> |
                   {{/if}}
                   {{#if @custom.instagram_page}}
-                  <a href={{ @custom.instagram_page }}>Instagram</a> |
+                  <a href={{ @custom.instagram_page }} target='_blank' rel='noopener'>Instagram</a> |
                   {{/if}}
                   {{#if @custom.facebook_page}}
-                  <a href={{ @custom.facebook_page }}>Facebook</a> |
+                  <a href={{ @custom.facebook_page }} target='_blank' rel='noopener'>Facebook</a> |
                   {{/if}}
                   {{#if @custom.reddit_page}}
-                  <a href={{ @custom.reddit_page }}>Reddit</a> |
+                  <a href={{ @custom.reddit_page }} target='_blank' rel='noopener'>Reddit</a> |
                   {{/if}}
                   {{#if @custom.youtube_page}}
-                  <a href={{ @custom.youtube_page }}>YouTube</a>
+                  <a href={{ @custom.youtube_page }} target='_blank' rel='noopener'>YouTube</a>
                   {{/if}}
                 </div>
               {{!-- List of tags  --}}

--- a/src/js/post.js
+++ b/src/js/post.js
@@ -111,7 +111,7 @@ const prepareProgressCircle = () => {
 
 const hideHardCodedFollowUs = () => {
   $("p").filter(function () {
-    return $(this).text().includes("Follow us on our official channels");
+    return $(this).text().includes("Follow Assembly on our official channels");
   }).hide().next('p').hide();
 }
 

--- a/src/js/post.js
+++ b/src/js/post.js
@@ -111,7 +111,8 @@ const prepareProgressCircle = () => {
 
 const hideHardCodedFollowUs = () => {
   $("p").filter(function () {
-    return $(this).text().includes("Follow Assembly on our official channels");
+    const text = $(this).text();
+    return text.includes("Follow Assembly on our official channels") || text.includes("Follow Assembly on the official channels");
   }).hide().next('p').hide();
 }
 


### PR DESCRIPTION
Closes #39 
Closes #40 

Replaced messages:
`Follow Assembly on our official channels`
`Follow Assembly on the official channels and stay up to date!`